### PR TITLE
Anchoring grace period

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+.DS_Store

--- a/StateMachine.js
+++ b/StateMachine.js
@@ -25,13 +25,13 @@ class StateMachine {
   setState(state, update) {
     if (state !== this.lastState) {
       debug(`State has changed from ${this.lastState} to ${state}`);
-      this.stateChangeTime = update.time;
+      this.stateChangeTime = update.time || new Date();
       if (update.path === 'navigation.position') {
         this.setPosition(update.value);
       }
       this.lastState = state;
     } else if (state === sailing || state === motoring) {
-      this.stateChangeTime = update.time;
+      this.stateChangeTime = update.time || new Date();
       if (update.path === 'navigation.position') {
         this.setPosition(update.value);
       }

--- a/StateMachine.js
+++ b/StateMachine.js
@@ -73,7 +73,12 @@ class StateMachine {
         return this.setState(anchored, update);
       }
       // With null value the anchor is hoisted
-      return this.setState(this.currentPropulsion, update);
+      const newState = this.setState(this.currentPropulsion, update);
+      // Here we need to give a bit more time from deactivating anchor alarm
+      // to getting under way without a "fake moored" in between
+      this.stateChangeTime.setMinutes(this.stateChangeTime.getMinutes() + 5);
+
+      return newState;
     }
 
     if (update.path.match(/propulsion\.([A-Za-z0-9]+)\.state/)) {

--- a/test/anchored-to-sailing.js
+++ b/test/anchored-to-sailing.js
@@ -1,0 +1,47 @@
+const geolocationUtils = require('geolocation-utils');
+const StateMachine = require('../StateMachine');
+const stateUpdate = require('./utils/stateUpdate');
+
+describe('transition from anchored to sailing', () => {
+  const stateMachine = new StateMachine();
+  const initialPoint = {
+    lat: 60.254558,
+    lon: 25.042828,
+  };
+  const pointOutOfBounds = geolocationUtils.moveTo(initialPoint, {
+    heading: 90,
+    distance: 101,
+  });
+  const pointOutOfBounds2 = geolocationUtils.moveTo(pointOutOfBounds, {
+    heading: 90,
+    distance: 400,
+  });
+  const pointOutOfBounds3 = geolocationUtils.moveTo(pointOutOfBounds2, {
+    heading: 90,
+    distance: 400,
+  });
+  after(() => {
+    stateUpdate.reset();
+  });
+  it('should set state as anchored when given anchor position', () => {
+    stateUpdate.anchor(stateMachine, 'anchored', {
+      latitude: 60.254558,
+      longitude: 25.042828,
+    }, 0);
+  });
+  it('should remain anchored despite moving about', () => {
+    stateUpdate.position(stateMachine, 'anchored', pointOutOfBounds.lat, pointOutOfBounds.lon, 20);
+  });
+  it('should set state as sailing when given NULL anchor position', () => {
+    stateUpdate.anchor(stateMachine, 'sailing', null, 4);
+  });
+  it('should return that we are sailing, when position has not changed within 10min of hoisting anchor', () => {
+    stateUpdate.position(stateMachine, 'sailing', pointOutOfBounds.lat, pointOutOfBounds.lon, 10);
+  });
+  it('should return that we are sailing, when position has changed and 10 minutes have not elapsed', () => {
+    stateUpdate.position(stateMachine, 'sailing', pointOutOfBounds2.lat, pointOutOfBounds2.lon, 5);
+  });
+  it('should return that we are sailing, when position has changed and 10 minutes have elapsed', () => {
+    stateUpdate.position(stateMachine, 'sailing', pointOutOfBounds3.lat, pointOutOfBounds3.lon, 10);
+  });
+});

--- a/test/utils/stateUpdate.js
+++ b/test/utils/stateUpdate.js
@@ -17,6 +17,17 @@ module.exports = {
     assert.equal(stateMachine.update(update), expectedState);
   },
 
+  anchor: (stateMachine, expectedState, value, minutesElapsed) => {
+    const update = {
+      path: 'navigation.anchor.position',
+      time: latestTime || new Date(),
+      value,
+    };
+    update.time.setMinutes(update.time.getMinutes() + minutesElapsed);
+    latestTime = new Date(update.time.getTime());
+    assert.equal(stateMachine.update(update), expectedState);
+  },
+
   positionWithRealGpsData: (
     stateMachine,
     expectedState,


### PR DESCRIPTION
Provide a bit longer period after anchor has been hoisted (or more accurately,  anchor alarm is deactivated) before unmoving boat is considered moored.