### PR TITLE
Round the observation window to whole minutes so moored detection survives sample jitter

### DIFF
--- a/StateMachine.js
+++ b/StateMachine.js
@@ -160,7 +160,13 @@ class StateMachine {
         distance.speed = distance.dist / distance.time;
       }
       if (distance.dist < this.underWayThresholdMeters) {
-        if ((distance.time / 60) < this.positionUpdateMinutes) {
+        // Round to whole minutes, like the staleness check above does. The
+        // accumulated window is bounded by the sample buffer, so comparing the
+        // exact figure makes this check fail permanently when the samples do
+        // not land precisely on the sampling period (for example a 1 Hz GPS
+        // behind a throttled subscription, where they arrive a few seconds
+        // early and get dropped by the one-per-minute guard).
+        if (Math.round(distance.time / 60) < this.positionUpdateMinutes) {
           debug(`Has only moved ${Math.round(distance.dist)} meters in ${Math.round(distance.time / 60)} minutes (${distance.speed.toFixed(2)}m/s). Ignoring since below time treshold`);
           return this.lastState;
         }

--- a/test/moored-sample-jitter.test.js
+++ b/test/moored-sample-jitter.test.js
@@ -1,0 +1,56 @@
+const assert = require('assert');
+const StateMachine = require('../StateMachine');
+
+// Regression test for the case where position updates do not land exactly on
+// the sampling period. A 1 Hz GPS combined with a throttled Signal K
+// subscription produces samples that are a few seconds shorter than the
+// nominal period. Those samples used to be dropped by the "one sample per
+// minute" guard, so the accumulated observation window never reached
+// positionUpdateMinutes and `moored` was never reached: the vessel stayed
+// `motoring` forever while tied to a dock.
+describe('moored with position updates slightly faster than the sampling period', () => {
+  const START = new Date('2026-01-01T12:00:00Z').getTime();
+  const LAT = 60.254558;
+  const LON = 25.042828;
+
+  function position(stateMachine, secondsFromStart, lat, lon) {
+    return stateMachine.update({
+      path: 'navigation.position',
+      value: { latitude: lat, longitude: lon },
+      time: new Date(START + secondsFromStart * 1000),
+    });
+  }
+
+  [57, 58, 59, 60].forEach((cadence) => {
+    it(`reaches moored with position updates every ${cadence} s`, () => {
+      const stateMachine = new StateMachine(10, 100, 'motoring', 0, true);
+      let seconds = 0;
+      let state = null;
+
+      // Get the vessel under way first: move roughly 300 m per minute.
+      stateMachine.update({
+        path: 'navigation.speedOverGround',
+        value: 5,
+        time: new Date(START),
+      });
+      for (let i = 1; i <= 15; i += 1) {
+        seconds += 60;
+        state = position(stateMachine, seconds, LAT + i * 0.0027, LON);
+      }
+      assert.equal(state, 'motoring', 'vessel should be under way before mooring');
+
+      // Now the vessel stops and stays in place, but the samples arrive
+      // slightly faster than the nominal sampling period.
+      stateMachine.update({
+        path: 'navigation.speedOverGround',
+        value: 0.05,
+        time: new Date(START + seconds * 1000),
+      });
+      for (let i = 1; i <= 60 && state !== 'moored'; i += 1) {
+        seconds += cadence;
+        state = position(stateMachine, seconds, LAT, LON);
+      }
+      assert.equal(state, 'moored', `still ${state} after 60 stationary samples`);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #237.

The observation window used by the `moored` check is bounded both by the sample buffer
(`positionUpdateMinutes + 1` entries) and by the staleness filter, so in the nominal
one-sample-per-minute case it sums to *exactly* `positionUpdateMinutes`. Comparing that without
rounding leaves zero headroom: one dropped sample puts the total permanently below the threshold
and the vessel never returns to `moored`.

Samples are dropped whenever the position updates do not land precisely on the sampling period.
The subscription asks for a 60 s period at the default setting, while `update()` rejects any
sample arriving less than 60 s after the previous one — so with a 1 Hz GPS, whose delta
timestamps sit on the fix grid, roughly half the samples are rejected and the effective interval
doubles.

**The change:** round to whole minutes, exactly like the staleness check a few lines above
already does. The boundary moves by at most 30 seconds.

I deliberately kept the one-sample-per-minute guard untouched. Relaxing it (my first attempt was
45 s) lets more samples into the fixed-size buffer, which *shrinks* the span it can cover and
broke `test/gps-data.js` — the invariant that the buffer holds one sample per minute is load
bearing.

**Testing**

- New `test/moored-sample-jitter.test.js` drives the state machine from under way to stationary
  with samples every 57, 58, 59 and 60 s. Before the change the 57/58/59 s cases never reach
  `moored`; after it, all four do.
- The existing suite stays green: 46 passing, 1 pending.